### PR TITLE
add cross-env so NO_DB_LOG works for mac devs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "type": "commonjs",
   "scripts": {
-    "test": "set NO_DB_LOG=true&& jest --verbose --runInBand --testLocationInResults --setupFiles dotenv/config",
+    "test": "cross-env NO_DB_LOG=true jest --verbose --runInBand --testLocationInResults --setupFiles dotenv/config",
     "test:watch": "npm run test -- --watch",
     "start": "node -r dotenv/config server.js",
     "start:watch": "nodemon -r dotenv/config server.js",


### PR DESCRIPTION
Requires `npm i` after pull